### PR TITLE
Fix bugs on attachments

### DIFF
--- a/includes/class-cf7-grid-layout.php
+++ b/includes/class-cf7-grid-layout.php
@@ -250,7 +250,8 @@ class Cf7_Grid_Layout {
     //instroduced a dynamic taxonomy droppdown tag for forms
     $this->loader->add_action( 'wpcf7_init', $plugin_public, 'register_cf7_shortcode' );
     //setup individual tag filers
-    //$this->loader->add_filter( 'wpcf7_posted_data', $plugin_public, 'setup_grid_values', 5, 1 );
+    $this->loader->add_filter( 'wpcf7_posted_data', $plugin_public, 'setup_grid_values', 5, 1 );
+    
     //filter cf7 validation
     $this->loader->add_filter( 'wpcf7_validate', $plugin_public, 'filter_wpcf7_validate', 30, 2 );
     

--- a/includes/class-cf7-grid-layout.php
+++ b/includes/class-cf7-grid-layout.php
@@ -250,9 +250,10 @@ class Cf7_Grid_Layout {
     //instroduced a dynamic taxonomy droppdown tag for forms
     $this->loader->add_action( 'wpcf7_init', $plugin_public, 'register_cf7_shortcode' );
     //setup individual tag filers
-    $this->loader->add_filter( 'wpcf7_posted_data', $plugin_public, 'setup_grid_values', 5, 1 );
+    //$this->loader->add_filter( 'wpcf7_posted_data', $plugin_public, 'setup_grid_values', 5, 1 );
     //filter cf7 validation
     $this->loader->add_filter( 'wpcf7_validate', $plugin_public, 'filter_wpcf7_validate', 30, 2 );
+    
     //benchmark validation
     $this->loader->add_filter( 'wpcf7_validate_dynamic_select*', $plugin_public, 'validate_required', 30, 2 );
     $this->loader->add_filter( 'wpcf7_validate_benchmark*', $plugin_public, 'validate_required', 30, 2 );

--- a/public/js/cf7-grid-layout-public.js
+++ b/public/js/cf7-grid-layout-public.js
@@ -19,8 +19,8 @@
   }
 
   $(document).ready( function(){
-    var $toggleHiddenStatus = $('input[name="_cf7sg_fields"]', $('form.wpcf7-form'));
-    $toggleHiddenStatus.val("");
+    var $fieldHiddenStatus = $('input[name="_cf7sg_fields"]', $('form.wpcf7-form'));
+    $fieldHiddenStatus.val("");
     var $toggleHiddenStatus = $('input[name="_cf7sg_toggles"]', $('form.wpcf7-form'));
     $toggleHiddenStatus.val("");
     


### PR DESCRIPTION
-Double in attachments (as the first FILE is already processed by the original plugin)
-"+" operator  replaced  by array_unique(array_merge...)) as "+" is an union on keys and not values.
-"dup_tag" replaced by "sg_field_tag"
-$components['attachments'] is an array, use the addition operator
-"apply_filters" instead of "apply_fitlers"